### PR TITLE
shell bug: ! is causing problems when used in strings

### DIFF
--- a/loop.iml
+++ b/loop.iml
@@ -3,25 +3,19 @@
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/test-annotations" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" />
-      <excludeFolder url="file://$MODULE_DIR$/target/archive-tmp" />
-      <excludeFolder url="file://$MODULE_DIR$/target/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/target/maven-archiver" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire" />
-      <excludeFolder url="file://$MODULE_DIR$/target/surefire-reports" />
-      <excludeFolder url="file://$MODULE_DIR$/target/test-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: org.ow2.asm:asm:4.0" level="project" />
     <orderEntry type="library" name="Maven: org.ow2.asm:asm-util:4.0" level="project" />
     <orderEntry type="library" name="Maven: org.ow2.asm:asm-tree:4.0" level="project" />
-    <orderEntry type="library" name="Maven: org.sonatype.jline:jline:2.5" level="project" />
+    <orderEntry type="library" name="Maven: jline:jline:2.6" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mvel:mvel2:2.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.8.2" level="project" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
       <version>4.0</version>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.jline</groupId>
+      <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.5</version>
+      <version>2.6</version>
     </dependency>
 
 

--- a/src/loop/LoopShell.java
+++ b/src/loop/LoopShell.java
@@ -39,6 +39,7 @@ public class LoopShell {
 
     try {
       ConsoleReader reader = new ConsoleReader();
+      reader.setExpandEvents(false);
       reader.addCompleter(new MetaCommandCompleter());
 
       Unit shellScope = new Unit(null, ModuleDecl.SHELL);


### PR DESCRIPTION
Fixed a shell issue where '!' was causing an illegal argument exception when used in strings.  Updating to JLine 2.6 which supports a method to disable ! history. This fixes this problem.
