### PR TITLE
Use mvel.Beta8 instead of -SNAPSHOT which doesn't seem to exist. :)

### DIFF
--- a/loop.iml
+++ b/loop.iml
@@ -23,7 +23,7 @@
     <orderEntry type="library" name="Maven: org.ow2.asm:asm-util:4.0" level="project" />
     <orderEntry type="library" name="Maven: org.ow2.asm:asm-tree:4.0" level="project" />
     <orderEntry type="library" name="Maven: jline:jline:2.6" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mvel:mvel2:2.1.Beta8" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mvel:mvel2:2.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.8.2" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,10 @@
   <repositories>
     <repository>
       <id>codehaus</id>
-      <url>http://repository.codehaus.org</url>
+      <url>http://snapshots.repository.codehaus.org/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
 
@@ -36,7 +39,7 @@
     <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
-      <version>2.1.Beta8</version>
+      <version>2.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The -SNAPSHOT version is nowhere to be seen on here:
http://repository.codehaus.org/org/mvel/mvel2/

So the latest commit was still causing breakage. This got it to build.
