### PR TITLE
Fixed issue #9

### DIFF
--- a/src/loop/Executable.java
+++ b/src/loop/Executable.java
@@ -225,6 +225,8 @@ public class Executable {
     FunctionDecl main = scope.resolveFunction("main", false);
     if (main != null) {
       int args = main.arguments().children().size();
+      if(commandLine == null)
+    	  commandLine = new String[] {};
       try {
         if (args == 0)
           return compiled.getDeclaredMethod("main").invoke(null);


### PR DESCRIPTION
Parser will not throw a NullPointerException now when the main function has an argument declared but no command line arguments are given at runtime.
